### PR TITLE
expose the MAX_TYPESIZE to avoid duplication 

### DIFF
--- a/blosc/__init__.py
+++ b/blosc/__init__.py
@@ -67,6 +67,7 @@ from blosc.blosc_extension import (
     BLOSC_VERSION_DATE,
     BLOSC_MAX_BUFFERSIZE,
     BLOSC_MAX_THREADS,
+    BLOSC_MAX_TYPESIZE,
     )
 
 

--- a/blosc/blosc_extension.c
+++ b/blosc/blosc_extension.c
@@ -177,6 +177,7 @@ initblosc_extension(void)
   /* Integer macros */
   PyModule_AddIntMacro(m, BLOSC_MAX_BUFFERSIZE);
   PyModule_AddIntMacro(m, BLOSC_MAX_THREADS);
+  PyModule_AddIntMacro(m, BLOSC_MAX_TYPESIZE);
 
   /* String macros */
   PyModule_AddStringMacro(m, BLOSC_VERSION_STRING);
@@ -204,6 +205,7 @@ PyInit_blosc_extension(void) {
   /* Integer macros */
   PyModule_AddIntMacro(m, BLOSC_MAX_BUFFERSIZE);
   PyModule_AddIntMacro(m, BLOSC_MAX_THREADS);
+  PyModule_AddIntMacro(m, BLOSC_MAX_TYPESIZE);
 
   /* String macros */
   PyModule_AddStringMacro(m, BLOSC_VERSION_STRING);


### PR DESCRIPTION
(even if it is unlikely to change) 

I need this when checking the arguments to `create_bloscpack_header`.
