### PR TITLE
Fix `ImportError: No module named numpy` when numpy module not installed

### DIFF
--- a/blosc/test.py
+++ b/blosc/test.py
@@ -5,6 +5,12 @@ import ctypes
 import numpy
 import blosc
 
+try:
+    import numpy
+except ImportError:
+    has_numpy = False
+else:
+    has_numpy = True
 
 py3 = sys.version_info[0] == 3
 
@@ -96,6 +102,9 @@ class TestCodec(unittest.TestCase):
                 ['abc'])
 
     def test_pack_array_exceptions(self):
+        if not has_numpy:
+            self.fail('numpy not avalaible')
+
         self.assertRaises(TypeError, blosc.pack_array, 'abc')
         self.assertRaises(TypeError, blosc.pack_array, 1.0)
 


### PR DESCRIPTION
When importing `blosc` in environment without `numpy` i receive exception:

```
>>> import blosc
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mnt/data/Work/trash/tests/lib/python2.7/site-packages/blosc/__init__.py", line 46, in <module>
    from blosc.test import run as test
  File "/mnt/data/Work/trash/tests/lib/python2.7/site-packages/blosc/test.py", line 5, in <module>
    import numpy
ImportError: No module named numpy
```

I make `numpy` module optional in `blosc.test`.
