### PR TITLE
need to set the PYTHONPATH explicitly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ If curious, you may want to run a small benchmark that compares a plain
 NumPy array copy against compression through different compressors in
 your Blosc build::
 
-  $ python bench/compare-pack-ptr.py
+  $ PYTHONPATH=. python bench/compare-pack-ptr.py
 
 In case you find the results interesting, please report them back to the
 authors!


### PR DESCRIPTION
While it is true, that Python automatically add the current directory to the
PYTHONPATH, current direcory actually means the base directory of the script
that is being executed, in this case, the `bench` sub directory.

zsh» python bench/compare-pack-ptr.py
Traceback (most recent call last):
  File "bench/compare-pack-ptr.py", line 18, in <module>
    import blosc
ImportError: No module named blosc

1 zsh» PYTHONPATH=. python bench/compare-pack-ptr.py
Creating a large NumPy array with 10**7 int64 elements:
  [      0       1       2 ..., 9999997 9999998 9999999]
  Time for copying array with numpy.copy():     0.031 s

Using **\* blosclz **\* compressor::
  Time for pack_array/unpack_array:     0.117/0.086 s.Compr ratio: 136.24
  Time for compress_ptr/decompress_p    tr: 0.012/0.014 s.Compr ratio: 136.83
