### PR TITLE
actually remove numpy dependency

### DIFF
--- a/blosc/test.py
+++ b/blosc/test.py
@@ -2,7 +2,6 @@ from __future__ import division
 import sys
 import unittest
 import ctypes
-import numpy
 import blosc
 
 try:


### PR DESCRIPTION
The fix in  6165255 was incomplete and the problem remained in master. This fixes the issue, at least for the plain blosc import. Numpy still required for executing the doctests...
