### PR TITLE
propagate return value from failed tests

### DIFF
--- a/blosc/test.py
+++ b/blosc/test.py
@@ -187,7 +187,7 @@ def run(verbosity=2):
 
     # suite = unittest.TestLoader().discover(start_dir='.', pattern='test*.py')
     suite.addTests(unittest.TestLoader().loadTestsFromModule(blosc.toplevel))
-    unittest.TextTestRunner(verbosity=verbosity).run(suite)
+    assert unittest.TextTestRunner(verbosity=verbosity).run(suite).wasSuccessful()
 
 
 if __name__ == '__main__':

--- a/blosc/test.py
+++ b/blosc/test.py
@@ -177,7 +177,7 @@ class TestCodec(unittest.TestCase):
         self.assertRaises(TypeError, blosc.unpack_array, 1.0)
 
 
-def run():
+def run(verbosity=2):
     import blosc
     import blosc.toplevel
     blosc.print_versions()
@@ -187,7 +187,7 @@ def run():
 
     # suite = unittest.TestLoader().discover(start_dir='.', pattern='test*.py')
     suite.addTests(unittest.TestLoader().loadTestsFromModule(blosc.toplevel))
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    unittest.TextTestRunner(verbosity=verbosity).run(suite)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently when tests fail the result is printed on stdout, but it is hard for the caller to know that it failed. Fail verbosely instead.