### PR TITLE
Decompress from a bytes-like object

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -14,8 +14,8 @@ Changes from 1.2.7 to 1.2.8
 ===========================
 
 - Support bytes-like objects that support the buffer interface as input to
-  ``compress``. On Python 2.x this includes unicode, on Python 3.x it doesn't.
-  (#80 @esc)
+  ``compress`` and ``decompress``. On Python 2.x this includes unicode, on
+  Python 3.x it doesn't.  (#80 #94 @esc)
 
 - Various miscellaneous fixes and improvements.
 

--- a/blosc/blosc_extension.c
+++ b/blosc/blosc_extension.c
@@ -371,13 +371,28 @@ PyDoc_STRVAR(decompress__doc__,
 static PyObject *
 PyBlosc_decompress(PyObject *self, PyObject *args)
 {
+    Py_buffer view;
     PyObject *result_str;
     void *input, *output;
     size_t nbytes, cbytes;
+    char *format;
+    /* Accept some kind of input */
+    #if PY_MAJOR_VERSION <= 2
+        /* s* : bytes like object including unicode and anything that supports
+         * the buffer interface */
+        format = "s*:decompress";
+    #elif PY_MAJOR_VERSION >= 3
+        /* y* :bytes like object EXCLUDING unicode and anything that supports
+         * the buffer interface. This is the recommended way to accept binary
+         * data in Python 3. */
+        format = "y*:decompress";
+    #endif
 
-    if (!PyArg_ParseTuple(args, "s#:decompress", &input, &cbytes))
+    if (!PyArg_ParseTuple(args, format, &view))
       return NULL;
 
+    cbytes = view.len;
+    input = view.buf;
     /*  fetch the uncompressed size into nbytes */
     if (!get_nbytes(input, cbytes, &nbytes))
       return NULL;

--- a/blosc/test.py
+++ b/blosc/test.py
@@ -77,6 +77,24 @@ class TestCodec(unittest.TestCase):
         self.assertEqual(expected, blosc.compress(
             np.array([b'0123456789']), typesize=1))
 
+    def test_decompress_input_types(self):
+        import numpy as np
+        # assume the expected answer was compressed from bytes
+        expected = b'0123456789'
+        compressed = blosc.compress(expected, typesize=1)
+
+        # now for all the things that support the buffer interface
+        if not PY3X:
+            # Python 3 no longer has the buffer
+            self.assertEqual(expected, blosc.decompress(buffer(compressed)))
+        if not PY26:
+            # memoryview doesn't exist on Python 2.6
+            self.assertEqual(expected,
+                             blosc.decompress(memoryview(compressed)))
+
+        self.assertEqual(expected, blosc.decompress(bytearray(compressed)))
+        self.assertEqual(expected, blosc.decompress(np.array([compressed])))
+
     def test_compress_exceptions(self):
         s = b'0123456789'
 

--- a/blosc/toplevel.py
+++ b/blosc/toplevel.py
@@ -458,8 +458,6 @@ def decompress(bytesobj):
 
     """
 
-    _check_bytesobj(bytesobj)
-
     return _ext.decompress(bytesobj)
 
 

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -104,6 +104,40 @@ you can expect similar results.  However, 'lz4hc' is variation of
 'lz4' that typically spends more time compressing for a better
 compression ratio, so it is very good for read-only data.
 
+Supporting the buffer interface
+===============================
+
+As of version 1.2.8 python-blosc supports compressing and decompressing from
+any bytes-like object that supports the buffer-interface: this includes
+`buffer`, `memoryview` and `bytearray`::
+
+    >>> input_bytes = b"abcdefghijklmnopqrstuvwxyz"
+
+    >>> blosc.compress(input_bytes, typesize=1)
+    '\x02\x01\x03\x01\x1a\x00\x00\x00\x1a\x00\x00\x00*\x00\x00\x00abcdefghijklmnopqrstuvwxyz'
+
+    >>> blosc.compress(memoryview(input_bytes), typesize=1)
+    '\x02\x01\x03\x01\x1a\x00\x00\x00\x1a\x00\x00\x00*\x00\x00\x00abcdefghijklmnopqrstuvwxyz'
+
+    >>> blosc.compress(bytearray(input_bytes), typesize=1)
+    '\x02\x01\x03\x01\x1a\x00\x00\x00\x1a\x00\x00\x00*\x00\x00\x00abcdefghijklmnopqrstuvwxyz'
+
+    >>> compressed = blosc.compress(input_bytes, typesize=1)
+
+    >>> blosc.decompress(compressed)
+    'abcdefghijklmnopqrstuvwxyz'
+
+    >>> blosc.decompress(memoryview(compressed))
+    'abcdefghijklmnopqrstuvwxyz'
+
+    >>> blosc.decompress(bytearray(compressed))
+    'abcdefghijklmnopqrstuvwxyz'
+
+Note however, that there are subtle differences between Python 2.x and 3.x.
+For example, in Python 2.x we can compress/decompress both `str` and `unicode`
+types, whereas in Python 3.x we can only compress 'binary' data which does
+*not* include `unicode`.
+
 
 Packaging NumPy arrays
 ======================


### PR DESCRIPTION
Here goes the other half. String and unicode excluded, since they can not be
encoded reliably from compressed data anyway.