### PR TITLE
Appveyor v4

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,17 +6,19 @@ environment:
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
 
   matrix:
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.8"
-      PYTHON_ARCH: "32"
+    # SSE2 not supported
+    # - PYTHON: "C:\\Python27"
+    #   PYTHON_VERSION: "2.7.8"
+    #   PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7.8"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.1"
-      PYTHON_ARCH: "32"
+    # SSE2 not supported
+    # - PYTHON: "C:\\Python34"
+    #   PYTHON_VERSION: "3.4.1"
+    #   PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python34-x64"
       PYTHON_VERSION: "3.4.1"

--- a/c-blosc/blosc/shuffle.c
+++ b/c-blosc/blosc/shuffle.c
@@ -10,9 +10,20 @@
 #include "shuffle.h"
 #include "shuffle-common.h"
 #include "shuffle-generic.h"
-#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
+
+/* Visual Studio < 2013 does not have stdbool.h so here it is a replacement: */
+#if defined __STDC__ && defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L
+/* have a C99 compiler */
+typedef _Bool bool;
+#else
+/* do not have a C99 compiler */
+typedef unsigned char bool;
+#endif
+static const bool false = 0;
+static const bool true = 1;
+
 
 #if !defined(__clang__) && defined(__GNUC__) && defined(__GNUC_MINOR__) && \
     __GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)


### PR DESCRIPTION
This is only to show that https://github.com/Blosc/c-blosc/commit/b416370ab667a9337b4cdbae10966d8241f6d6a1 solves `c-blosc/blosc\shuffle.c(13) : fatal error C1083: Cannot open include file: 'stdbool.h': No such file or directory `
But now a linking problem rises up 
```
shuffle.obj : error LNK2019: unresolved external symbol blosc_get_cpu_features referenced in function get_shuffle_implementation
build\lib.win-amd64-2.7\blosc\blosc_extension.pyd : fatal error LNK1120: 1 unresolved externals
error: command 'C:\\Program Files (x86)\\Microsoft Visual Studio 9.0\\VC\\Bin\\amd64\\link.exe' failed with exit status 1120
Command exited
```

Btw I tried using `subtree-merge-blosc` but did not suceeded on that (I copied the script and called `./subtree-merge-blosc.sh master`), but from what I saw in the script a propper tag is needed vX.Y.Z, isn't it?.
I could also clone master from c-blosc and copy all changes, but this might not be the way you would like it.