### PR TITLE
[MRG] Better memory leak tests

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -18,7 +18,7 @@ Changes from 1.2.7 to 1.2.8
   Python 3.x it doesn't.  (#80 #94 @esc)
 
 - Fix a memory leak in ``decompress``.
-  Add (non deterministic) tests to catch memory leaks. (#102 #103 @sdvillal)
+  Add tests to catch memory leaks. (#102 #103 #104 @sdvillal)
 
 - Various miscellaneous fixes and improvements.
 

--- a/blosc/blosc_extension.c
+++ b/blosc/blosc_extension.c
@@ -414,7 +414,7 @@ PyBlosc_decompress(PyObject *self, PyObject *args)
       return NULL;
     }
 
-    PyBuffer_Release(&view);
+    // PyBuffer_Release(&view);
     return result_str;
 }
 

--- a/blosc/blosc_extension.c
+++ b/blosc/blosc_extension.c
@@ -414,7 +414,7 @@ PyBlosc_decompress(PyObject *self, PyObject *args)
       return NULL;
     }
 
-    // PyBuffer_Release(&view);
+    PyBuffer_Release(&view);
     return result_str;
 }
 


### PR DESCRIPTION
Just a continuation of #103, here we check only the memory of the current process. Way more robust.

I will let this fail in travis as a proof of concept, then refix the leak, update release notes and we will be ready to go.