### PR TITLE
tests: fix error with new numpy

### DIFF
--- a/blosc/test.py
+++ b/blosc/test.py
@@ -185,7 +185,7 @@ class TestCodec(unittest.TestCase):
         self.assertRaises(TypeError, blosc.pack_array, 'abc')
         self.assertRaises(TypeError, blosc.pack_array, 1.0)
 
-        items = (blosc.BLOSC_MAX_BUFFERSIZE / 8) + 1
+        items = (blosc.BLOSC_MAX_BUFFERSIZE // 8) + 1
         one = numpy.ones(1, dtype=numpy.int64)
         self.assertRaises(ValueError, blosc.pack_array, one, clevel=-1)
         self.assertRaises(ValueError, blosc.pack_array, one, clevel=10)


### PR DESCRIPTION
ERROR: test_pack_array_exceptions (blosc.test.TestCodec)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/builddir/build/BUILDROOT/python-blosc-1.2.8-2.fc24.i386/usr/lib/python2.7/site-packages/blosc/test.py", line 195, in test_pack_array_exceptions
    strides=(8, 0))[0]
  File "/usr/lib/python2.7/site-packages/numpy/lib/stride_tricks.py", line 48, in as_strided
    array = np.asarray(DummyArray(interface, base=x))
  File "/usr/lib/python2.7/site-packages/numpy/core/numeric.py", line 482, in asarray
    return array(a, dtype, copy=False, order=order)
TypeError: 'float' object cannot be interpreted as an index