### PR TITLE
Add as_bytearray=False flag to decompress.

### DIFF
--- a/blosc/test.py
+++ b/blosc/test.py
@@ -101,6 +101,28 @@ class TestCodec(unittest.TestCase):
         self.assertEqual(expected, blosc.decompress(bytearray(compressed)))
         self.assertEqual(expected, blosc.decompress(np.array([compressed])))
 
+    def test_decompress_input_types_as_bytearray(self):
+        import numpy as np
+        # assume the expected answer was compressed from bytes
+        expected = bytearray(b'0123456789')
+        compressed = blosc.compress(expected, typesize=1)
+
+        # now for all the things that support the buffer interface
+        if not PY3X:
+            # Python 3 no longer has the buffer
+            self.assertEqual(expected, blosc.decompress(buffer(compressed),
+                                                        as_bytearray=True))
+        if not PY26:
+            # memoryview doesn't exist on Python 2.6
+            self.assertEqual(expected,
+                             blosc.decompress(memoryview(compressed),
+                                              as_bytearray=True))
+
+        self.assertEqual(expected, blosc.decompress(bytearray(compressed),
+                                                    as_bytearray=True))
+        self.assertEqual(expected, blosc.decompress(np.array([compressed]),
+                                                    as_bytearray=True))
+
     def test_compress_exceptions(self):
         s = b'0123456789'
 

--- a/blosc/toplevel.py
+++ b/blosc/toplevel.py
@@ -421,7 +421,7 @@ def compress_ptr(address, items, typesize, clevel=9, shuffle=True,
     return _ext.compress_ptr(address, length, typesize, clevel, shuffle, cname)
 
 
-def decompress(bytesobj):
+def decompress(bytesobj, as_bytearray=False):
     """decompress(bytesobj)
 
     Decompresses a bytesobj compressed object.
@@ -430,11 +430,16 @@ def decompress(bytesobj):
     ----------
     bytesobj : str / bytes
         The data to be decompressed.
+    as_bytearray : bool, optional
+        If this flag is True then the return type will be a bytearray object
+        instead of a bytesobject.
 
     Returns
     -------
-    out : str / bytes
+    out : str / bytes or bytearray
         The decompressed data in form of a Python str / bytes object.
+        If as_bytearray is True then this will be a bytearray object, otherwise
+        this will be a str/ bytes object.
 
     Raises
     ------
@@ -455,10 +460,13 @@ def decompress(bytesobj):
     True
     >>> b"1"*7 == blosc.decompress(blosc.compress(b"1"*7, 8))
     True
+    >>> type(blosc.decompress(blosc.compress(b"1"*7, 8),
+    ...                                      as_bytearray=True)) is bytearray
+    True
 
     """
 
-    return _ext.decompress(bytesobj)
+    return _ext.decompress(bytesobj, as_bytearray)
 
 
 def decompress_ptr(bytesobj, address):
@@ -637,7 +645,7 @@ def unpack_array(packed_array):
     _check_bytesobj(packed_array)
 
     # First decompress the pickle
-    pickled_array = _ext.decompress(packed_array)
+    pickled_array = _ext.decompress(packed_array, False)
     # ... and unpickle
     array = pickle.loads(pickled_array)
 


### PR DESCRIPTION
To make it easier to decompress data into a mutable array without
copying there is a new flag 'as_bytearray' to the decompress
function. This will make decompress return a mutable array of bytes
instead of an immutable collection.

See https://github.com/pydata/pandas/pull/12359 for context on the use case.
About the implementation: I tried having a branch that set two function pointers, one for `from_string_and_size` and the other for `as_string` but that showed worse performance than just using CPP to specialize the two branches. If the you think that the slight performance increase is not worth the code complexity I can repush a change without using CPP for the two branches.