### PR TITLE
Added Python versions for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,11 @@ Intended Audience :: Information Technology
 Intended Audience :: Science/Research
 License :: OSI Approved :: MIT License
 Programming Language :: Python
+Programming Language :: Python :: 2.6
+Programming Language :: Python :: 2.7
+Programming Language :: Python :: 3.3
+Programming Language :: Python :: 3.4
+Programming Language :: Python :: 3.5
 Topic :: Software Development :: Libraries :: Python Modules
 Topic :: System :: Archiving :: Compression
 Operating System :: Microsoft :: Windows


### PR DESCRIPTION
This was motivated by the fact that [caniusepython3](https://github.com/brettcannon/caniusepython3) doesn't show that blosc supports Python3.