### PR TITLE
Nogil

### DIFF
--- a/bench/threadpool.py
+++ b/bench/threadpool.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+"""
+threadpool.py
+Created on Sun Oct 23 12:03:46 2016
+@author: Robert A. Mcleod - robbmcleod@gmail.com
+
+Compares running blosc with and without GIL release, and compares various
+combinations of ThreadPool threads and blosc-threads for operating on large 
+chunks.  The target is an image stack [50,1024,1024], where each frame can 
+be compressed as a chunk.
+"""
+
+from __future__ import print_function
+import numpy as np
+import time
+import blosc
+from multiprocessing.pool import ThreadPool
+
+nRuns = 10
+dtype='int64'
+m = 48
+N = 2048
+MegaBytes = m * N * N * np.dtype(dtype).itemsize / 2**20
+maxThreads = blosc.nthreads
+
+BLOCKSIZE = 2**20
+CLEVEL = 4
+SHUFFLE = blosc.SHUFFLE
+COMPRESSOR = 'zstd'
+                 
+def compressSlice( args ):
+    """
+    args = (numpy array address, array_size, item_size, bytesList, bytesIndex)
+    """
+    args[3][args[4]] = blosc.compress_ptr( args[0],  args[1], args[2], \
+                       clevel=CLEVEL, shuffle=SHUFFLE, cname=COMPRESSOR )
+
+def decompressSlice( J, list_bytes ):
+    # TODO
+    pass
+
+def compressStack( imageStack, blosc_threads = 1, pool_threads=maxThreads ):
+    """
+    Does subpixel translations shifts for a stack of images using a ThreadPool to distribute the load.
+    
+    I could make this a general function utility by passing in the function handle.  
+    """
+    blosc.set_nthreads( blosc_threads )
+    tPool = ThreadPool( pool_threads )
+
+    num_slices = imageStack.shape[0]
+    # Build parameters list for the threaded processeses, consisting of index
+    tArgs = [None] * num_slices
+    itemSize = imageStack.dtype.itemsize
+    bytesList = [None] * num_slices
+    for J in np.arange(num_slices):
+        tArgs[J] = (imageStack[J,:,:].__array_interface__['data'][0], \
+                    N*N, itemSize, bytesList, J)
+    
+    # All operations are done 'in-place' 
+    tPool.map( compressSlice, tArgs )
+    tPool.close()
+    tPool.join()
+
+
+blosc.print_versions()
+blosc.set_blocksize( BLOCKSIZE )
+print("Creating NumPy stack with %d float32 elements:" %(m*N*N) )
+
+stack = np.zeros( [m,N,N], dtype=dtype )
+xmesh, ymesh = np.meshgrid( np.arange(-N/2,N/2), np.arange(-N/2,N/2) )
+compress_mesh = (np.cos( xmesh ) + np.exp( -ymesh**2 / N )).astype(dtype)
+for J in np.arange(m):
+    stack[J,:,:] = compress_mesh
+
+#testCases = int( np.floor( np.log2( maxThreads )) + 1 )
+#powProduct = 2**np.arange(0,testCases)
+#poolThreads = np.hstack( [1, powProduct] )
+#bloscThreads = np.hstack( [1, powProduct[::-1]] )
+# Let's try instead just pool threads...
+poolThreads = np.arange( 1, maxThreads+1 )
+bloscThreads = np.ones_like( poolThreads )
+
+solo_times = np.zeros_like( poolThreads, dtype='float64' )
+solo_unlocked_times = np.zeros_like( poolThreads, dtype='float64' )
+locked_times = np.zeros_like( poolThreads, dtype='float64' )
+unlocked_times = np.zeros_like( poolThreads, dtype='float64' )
+
+for J in np.arange(nRuns):
+    print( "Run  %d of %d" % (J+1, nRuns) )
+    blosc.set_releasegil(False)
+    for I in np.arange( len(poolThreads) ):
+        t1 = time.time()
+        blosc.set_nthreads( bloscThreads[I] )
+        blosc.compress_ptr( stack.__array_interface__['data'][0], stack.size, stack.dtype.itemsize, \
+                       clevel=CLEVEL, shuffle=SHUFFLE, cname=COMPRESSOR )
+        solo_times[I] += time.time() - t1
+
+    blosc.set_releasegil(True)
+    for I in np.arange( len(poolThreads) ):
+        t2 = time.time()
+        blosc.set_nthreads( bloscThreads[I] )
+        blosc.compress_ptr( stack.__array_interface__['data'][0], stack.size, stack.dtype.itemsize, \
+                       clevel=CLEVEL, shuffle=SHUFFLE, cname=COMPRESSOR )
+        solo_unlocked_times[I] += time.time() - t2
+
+    blosc.set_releasegil(True)
+    for I in np.arange( len(poolThreads) ):
+        t3 = time.time()
+        compressStack( stack, blosc_threads=bloscThreads[I], pool_threads=poolThreads[I] )
+        unlocked_times[I] += time.time() - t3
+
+        
+    blosc.set_releasegil(False)
+    for I in np.arange( len(poolThreads) ):
+        t4 = time.time()
+        compressStack( stack, blosc_threads=bloscThreads[I], pool_threads=poolThreads[I] )
+        locked_times[I] += time.time() - t4
+      
+solo_times /= nRuns
+solo_unlocked_times /= nRuns
+locked_times /= nRuns
+unlocked_times /=nRuns
+print( "##### NO THREADPOOL -- GIL LOCKED #####" )
+for I in np.arange( len(poolThreads) ):
+    print( "    Compressed %.2f MB with %d pool threads, %d blosc threads in: %f s" \
+      % ( MegaBytes, 0, bloscThreads[I], solo_times[I]) )
+print( "##### NO THREADPOOL -- GIL RELEASED #####" )
+for I in np.arange( len(poolThreads) ):
+    print( "    Compressed %.2f MB with %d pool threads, %d blosc threads in: %f s" \
+      % ( MegaBytes, 0, bloscThreads[I], solo_unlocked_times[I]) )
+print( "##### GIL LOCKED w/ THREADPOOL #####" )
+for I in np.arange( len(poolThreads) ):
+    print( "    Compressed %.2f MB with %d pool threads, %d blosc threads in: %f s" \
+      % ( MegaBytes, poolThreads[I], bloscThreads[I], locked_times[I]) )
+print( "##### GIL RELEASED w/ THREADPOOL #####" )
+for I in np.arange( len(poolThreads) ):
+    print( "    Compressed %.2f MB with %d pool threads, %d blosc threads in: %f s" \
+      % ( MegaBytes, poolThreads[I], bloscThreads[I], unlocked_times[I]) )

--- a/blosc/__init__.py
+++ b/blosc/__init__.py
@@ -46,6 +46,7 @@ from blosc.toplevel import (
     free_resources,
     set_nthreads,
     set_blocksize,
+    set_releasegil,
     compressor_list,
     code_to_name,
     name_to_code,
@@ -64,6 +65,10 @@ clib_versions = dict(clib_info(name) for name in cnames)
 
 # Initialize Blosc
 init()
+# RAM: default to keep GIL, since it's just extra overhead if we aren't 
+# threading ourselves
+set_releasegil(False)
+# Internal Blosc threading
 nthreads = ncores = detect_number_of_cores()
 # Protection against too many cores
 if nthreads > 4:
@@ -72,6 +77,7 @@ set_nthreads(nthreads)
 blosclib_version = "%s (%s)" % (VERSION_STRING, VERSION_DATE)
 import atexit
 atexit.register(destroy)
+
 
 # Tests
 from blosc.test import run as test

--- a/blosc/test.py
+++ b/blosc/test.py
@@ -112,7 +112,27 @@ class TestCodec(unittest.TestCase):
 
         self.assertEqual(expected, blosc.decompress(bytearray(compressed)))
         self.assertEqual(expected, blosc.decompress(np.array([compressed])))
+        
+    def test_decompress_releasegil(self):
+        import numpy as np
+        # assume the expected answer was compressed from bytes
+        blosc.set_releasegil(True)
+        expected = b'0123456789'
+        compressed = blosc.compress(expected, typesize=1)
 
+        # now for all the things that support the buffer interface
+        if not PY3X:
+            # Python 3 no longer has the buffer
+            self.assertEqual(expected, blosc.decompress(buffer(compressed)))
+        if not PY26:
+            # memoryview doesn't exist on Python 2.6
+            self.assertEqual(expected,
+                             blosc.decompress(memoryview(compressed)))
+
+        self.assertEqual(expected, blosc.decompress(bytearray(compressed)))
+        self.assertEqual(expected, blosc.decompress(np.array([compressed])))
+        blosc.set_releasegil(False)
+        
     def test_decompress_input_types_as_bytearray(self):
         import numpy as np
         # assume the expected answer was compressed from bytes

--- a/blosc/toplevel.py
+++ b/blosc/toplevel.py
@@ -115,7 +115,28 @@ def set_blocksize(blocksize):
     """
 
     _ext.set_blocksize(blocksize)
-
+    
+def set_releasegil( gilstate ):
+    """
+    set_releasegil( gitstate )
+    
+    Sets a boolean on whether to release the Python global inter-lock (GIL) 
+    during c-blosc compress and decompress operations or not.  This defaults 
+    to False.
+    
+    Notes
+    -----
+    
+    Designed to be used with larger chunk sizes and a ThreadPool.
+    
+    Examples
+    --------
+    
+    >>> oldReleaseState = blosc.set_releasegil(True)
+    
+    """
+    gilstate = bool(gilstate)
+    return _ext.set_releasegil( gilstate )
 
 def compressor_list():
     """


### PR DESCRIPTION
Permits release of Python Global Interpreter Lock (GIL) inside of c-blosc calls.  Tested with bench/threadpool.py using the multiprocesing.ThreadPool class to map the operations in compressing frames of an image stack (aka movie).  Intended to be used in situations where other bounds (e.g. file I/O, network I/O) could be significant, such that asychronous read/write/compress operations could make the compression step essentially free.

Usage:
blosc.set_releasegil(True)
# Operate multiple blosc streams at a time
