### PR TITLE
Separate compilation of codecs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,8 @@ blosc/blosc_extension.so
 blosc/version.py
 build/
 doc/_build/
+dist/
+blosc.egg-info/
 *~
 *.pyc
+

--- a/README.rst
+++ b/README.rst
@@ -46,22 +46,23 @@ to link with an already installed Blosc library or not.
 Installing via setuptools
 -------------------------
 
+`python-blosc` comes with the Blosc sources with it and can be built with:
+
+.. code-block:: console
+
+    $ python setup.py build_ext --inplace
+
+Any codec can be enabled (`=1`) or disabled (`=0`) on this build-path with the appropriate
+OS environment variables `INCLUDE_LZ4`, `INCLUDE_SNAPPY`, `INCLUDE_ZLIB`, and 
+`INCLUDE_ZLIB`. By default all the codecs in Blosc are enabled except Snappy 
+(due to some issues with C++ with the `gcc` toolchain).
+
 `setuptools` is limited to using the compiler specified in the environment 
 variable `CC` which on posix systems is usually `gcc`. This often causes 
 trouble with the Snappy codec, which is written in C++, and as a result Snappy
 is no longer compiled by default. This problem is not known to affect MSVC or 
 clang. Snappy is considered optional in Blosc as its compression performance 
 is below that of the other codecs.
-
-Any codec can be enabled (`=1`) or disabled (`=0`) on this build-path with the appropriate
-OS environment variables `INCLUDE_LZ4`, `INCLUDE_SNAPPY`, `INCLUDE_ZLIB`, and 
-`INCLUDE_ZLIB`. Snappy is disabled by default on posix systems.
-
-`python-blosc` comes with the Blosc sources with it and can be built with:
-
-.. code-block:: console
-
-    $ python setup.py build_ext --inplace
 
 That's all. You can proceed with testing section now.
 

--- a/README.rst
+++ b/README.rst
@@ -42,13 +42,35 @@ Building
 There are different ways to compile python-blosc, depending if you want
 to link with an already installed Blosc library or not.
 
-Compiling with an installed Blosc library (recommended)
--------------------------------------------------------
 
-Python and Blosc-powered extensions have a difficult relationship when
-compiled using GCC, so this is why using an external C-Blosc library is
-recommended for maximum performance (for details, see
-https://github.com/Blosc/python-blosc/issues/110).
+Installing via setuptools
+-------------------------
+
+`setuptools` is limited to using the compiler specified in the environment 
+variable `CC` which on posix systems is usually `gcc`. This often causes 
+trouble with the Snappy codec, which is written in C++, and as a result Snappy
+is no longer compiled by default. This problem is not known to affect MSVC or 
+clang. Snappy is considered optional in Blosc as its compression performance 
+is below that of the other codecs.
+
+Any codec can be enabled (`=1`) or disabled (`=0`) on this build-path with the appropriate
+OS environment variables `INCLUDE_LZ4`, `INCLUDE_SNAPPY`, `INCLUDE_ZLIB`, and 
+`INCLUDE_ZLIB`. Snappy is disabled by default on posix systems.
+
+`python-blosc` comes with the Blosc sources with it and can be built with:
+
+.. code-block:: console
+
+    $ python setup.py build_ext --inplace
+
+That's all. You can proceed with testing section now.
+
+
+Compiling with an installed Blosc library
+-----------------------------------------
+
+This approach uses pre-built, fully optimized versions of Blosc built via
+CMake. 
 
 Go to https://github.com/Blosc/c-blosc/releases and download and install
 the C-Blosc library.  Then, you can tell python-blosc where is the
@@ -68,24 +90,6 @@ Using a flag:
 
     $ python setup.py build_ext --inplace --blosc=/usr/local
 
-Compiling without an installed Blosc library
---------------------------------------------
-
-*Warning:* This way of compiling is discouraged for performance reasons.
-See the previous section.
-
-python-blosc also comes with the Blosc sources with it so, assuming that
-you have a C++ compiler installed, do:
-
-.. code-block:: console
-
-    $ python setup.py build_ext --inplace
-
-That's all.  You can proceed with testing section now.
-
-Note: The requirement for the C++ compiler is just for the Snappy
-dependency.  The rest of the other components of Blosc are pure C
-(including the LZ4, Zstd and Zlib libraries).
 
 Testing
 =======

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -31,23 +31,38 @@ https://github.com/Blosc/python-blosc and download the sources.
 Then, there are different ways to compile python-blosc, depending on whether
 you want to link with an already installed Blosc library or not.
 
-Compiling without an installed Blosc library
---------------------------------------------
+Installing via setuptools
+-------------------------
 
-python-blosc comes with the Blosc sources with it so, assuming that you
-have a C compiler installed, do:
+`setuptools` is limited to using the compiler specified in the environment 
+variable `CC` which on posix systems is usually `gcc`. This often causes 
+trouble with the Snappy codec, which is written in C++, and as a result Snappy
+is no longer compiled by default. This problem is not known to affect MSVC or 
+clang. Snappy is considered optional in Blosc as its compression performance 
+is below that of the other codecs.
+
+Any codec can be enabled (`=1`) or disabled (`=0`) on this build-path with the appropriate
+OS environment variables `INCLUDE_LZ4`, `INCLUDE_SNAPPY`, `INCLUDE_ZLIB`, and 
+`INCLUDE_ZLIB`. Snappy is disabled by default on posix systems.
+
+`python-blosc` comes with the Blosc sources with it and can be built with:
 
 .. code-block:: console
 
     $ python setup.py build_ext --inplace
 
-That's all.  You can proceed with testing section now.
+That's all. You can proceed with testing section now.
+
 
 Compiling with an installed Blosc library
 -----------------------------------------
 
-In case you have Blosc installed as an external library (and disregard
-the included Blosc sources) you can link with it in a couple of ways.
+This approach uses pre-built, fully optimized versions of Blosc built via
+CMake. 
+
+Go to https://github.com/Blosc/c-blosc/releases and download and install
+the C-Blosc library.  Then, you can tell python-blosc where is the
+C-Blosc library in a couple of ways:
 
 Using an environment variable:
 
@@ -56,12 +71,13 @@ Using an environment variable:
     $ BLOSC_DIR=/usr/local     (or "set BLOSC_DIR=\blosc" on Win)
     $ export BLOSC_DIR         (not needed on Win)
     $ python setup.py build_ext --inplace
-
+ 
 Using a flag:
 
 .. code-block:: console
 
     $ python setup.py build_ext --inplace --blosc=/usr/local
+
 
 Generating Sphinx documentation
 -------------------------------

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -34,22 +34,23 @@ you want to link with an already installed Blosc library or not.
 Installing via setuptools
 -------------------------
 
+`python-blosc` comes with the Blosc sources with it and can be built with:
+
+.. code-block:: console
+
+    $ python setup.py build_ext --inplace
+
+Any codec can be enabled (`=1`) or disabled (`=0`) on this build-path with the appropriate
+OS environment variables `INCLUDE_LZ4`, `INCLUDE_SNAPPY`, `INCLUDE_ZLIB`, and 
+`INCLUDE_ZLIB`. By default all the codecs in Blosc are enabled except Snappy 
+(due to some issues with C++ with the `gcc` toolchain).
+
 `setuptools` is limited to using the compiler specified in the environment 
 variable `CC` which on posix systems is usually `gcc`. This often causes 
 trouble with the Snappy codec, which is written in C++, and as a result Snappy
 is no longer compiled by default. This problem is not known to affect MSVC or 
 clang. Snappy is considered optional in Blosc as its compression performance 
 is below that of the other codecs.
-
-Any codec can be enabled (`=1`) or disabled (`=0`) on this build-path with the appropriate
-OS environment variables `INCLUDE_LZ4`, `INCLUDE_SNAPPY`, `INCLUDE_ZLIB`, and 
-`INCLUDE_ZLIB`. Snappy is disabled by default on posix systems.
-
-`python-blosc` comes with the Blosc sources with it and can be built with:
-
-.. code-block:: console
-
-    $ python setup.py build_ext --inplace
 
 That's all. You can proceed with testing section now.
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ from setuptools import Extension
 from setuptools import setup
 from glob import glob
 import cpuinfo
-from numpy.distutils.misc_util import get_numpy_include_dirs
 
 ########### Check versions ##########
 def exit_with_error(message):
@@ -76,7 +75,7 @@ clibs = [] # for build_clib, libraries TO BE BUILT
 
 # Below are parameters for the Extension object
 sources = ["blosc/blosc_extension.c"]
-inc_dirs = [get_numpy_include_dirs()]
+inc_dirs = []
 lib_dirs = []
 libs = []  # Pre-built libraries ONLY, like python36.so
 def_macros = []

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ########################################################################
 #
-#       License: MIT
+#       License: BSD 3-clause
 #       Created: September 22, 2010
 #       Author:  Francesc Alted - faltet@gmail.com
 #
@@ -20,10 +20,9 @@ from setuptools import Extension
 from setuptools import setup
 from glob import glob
 import cpuinfo
+from numpy.distutils.misc_util import get_numpy_include_dirs
 
 ########### Check versions ##########
-
-
 def exit_with_error(message):
     print('ERROR: %s' % message)
     sys.exit(1)
@@ -43,7 +42,6 @@ if sys.version_info[:2] < (2, 7):
     tests_require += ['unittest2']
 
 ########### End of checks ##########
-
 
 # Blosc version
 VERSION = open('VERSION').read().strip()
@@ -69,11 +67,18 @@ for arg in args:
         CFLAGS = arg.split('=')[1].split()
         sys.argv.remove(arg)
 
+
 # Blosc sources and headers
+
+# To avoid potential namespace collisions use build_clib.py for each codec
+# instead of co-compiling all sources files in one setuptools.Extension object.
+clibs = [] # for build_clib, libraries TO BE BUILT
+
+# Below are parameters for the Extension object
 sources = ["blosc/blosc_extension.c"]
-inc_dirs = []
+inc_dirs = [get_numpy_include_dirs()]
 lib_dirs = []
-libs = []
+libs = []  # Pre-built libraries ONLY, like python36.so
 def_macros = []
 if BLOSC_DIR != '':
     # Using the Blosc library
@@ -81,18 +86,36 @@ if BLOSC_DIR != '':
     inc_dirs += [os.path.join(BLOSC_DIR, 'include')]
     libs += ['blosc']
 else:
+    # Libraries to be built with build_clib
+    clibs.append( ('lz4', {'sources': glob('c-blosc/internal-complibs/lz4*/*.c')} ) )
+
+    # Tried and failed to compile Snappy with gcc using 'cflags' on posix
+    # setuptools always uses gcc instead of g++, as it only checks for the 
+    # env var 'CC' and not 'CXX'.
+    clibs.append( ('snappy', {'sources': glob('c-blosc/internal-complibs/snappy*/*.cc'), 
+                               'cflags':'-std=c++11 -lstdc++' } ) )
+
+    clibs.append( ('zlib', {'sources': glob('c-blosc/internal-complibs/zlib*/*.c')} ) )
+
+    clibs.append( ('zstd', {'sources': glob('c-blosc/internal-complibs/zstd*/*/*.c'), 
+                    'include_dirs': glob('c-blosc/internal-complibs/zstd*') + glob('c-blosc/internal-complibs/zstd*/common') } ) )
+    # TODO: do we want env vars checks to disable libraries and macros?
+
+    # Configure the Extension
     # Compiling everything from included C-Blosc sources
     sources += [f for f in glob('c-blosc/blosc/*.c')
                 if 'avx2' not in f and 'sse2' not in f]
-    sources += glob('c-blosc/internal-complibs/lz4*/*.c')
-    sources += glob('c-blosc/internal-complibs/snappy*/*.cc')
-    sources += glob('c-blosc/internal-complibs/zlib*/*.c')
-    sources += glob('c-blosc/internal-complibs/zstd*/*/*.c')
+
     inc_dirs += [os.path.join('c-blosc', 'blosc')]
     inc_dirs += glob('c-blosc/internal-complibs/*')
+    inc_dirs += glob('c-blosc/internal-complibs/lz4*')
+    inc_dirs += glob('c-blosc/internal-complibs/snappy*')
     inc_dirs += glob('c-blosc/internal-complibs/zstd*/common')
     inc_dirs += glob('c-blosc/internal-complibs/zstd*')
-    def_macros += [('HAVE_LZ4', 1), ('HAVE_SNAPPY', 1), ('HAVE_ZLIB', 1), ('HAVE_ZSTD', 1)]
+    
+    # To undefine SNAPPY we have to not define the macro, as opposed to setting it to False
+    def_macros += [('HAVE_LZ4', 1), ('HAVE_SNAPPY', 1), ('HAVE_ZLIB', 1), ('HAVE_ZSTD', 1) ]
+    
 
     # Guess SSE2 or AVX2 capabilities
     cpu_info = cpuinfo.get_cpu_info()
@@ -114,6 +137,7 @@ else:
             CFLAGS.append('-mavx2')
         elif os.name == 'nt':
             def_macros += [('__AVX2__', 1)]
+    # TODO: AVX512
 
 classifiers = """\
 Development Status :: 5 - Production/Stable
@@ -127,6 +151,7 @@ Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3.3
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
+Programming Language :: Python :: 3.6
 Topic :: Software Development :: Libraries :: Python Modules
 Topic :: System :: Archiving :: Compression
 Operating System :: Microsoft :: Windows
@@ -147,8 +172,9 @@ Blosc is a high performance compressor optimized for binary data.
       maintainer = 'Francesc Alted',
       maintainer_email = 'faltet@gmail.com',
       url = 'http://github.com/blosc/python-blosc',
-      license = 'http://www.opensource.org/licenses/mit-license.php',
+      license = 'https://opensource.org/licenses/BSD-3-Clause',
       platforms = ['any'],
+      libraries = clibs,
       ext_modules = [
         Extension( "blosc.blosc_extension",
                    include_dirs=inc_dirs,
@@ -160,6 +186,7 @@ Blosc is a high performance compressor optimized for binary data.
                    extra_compile_args=CFLAGS ),
         ],
       tests_require=tests_require,
+      zip_safe=False,
       packages = ['blosc'],
 
 )


### PR DESCRIPTION
Makes use of the `setuptools` build_clib command to separate the codec builds, and thereby prevent namespace collisions and allows for different `cflags` among codecs.  Unfortunately `setuptools` cannot support different compilers for Snappy so the Linux problems for that codec are still present.