### PR TITLE
fixes for building via setup.py on aarch64

### DIFF
--- a/cpuinfo.py
+++ b/cpuinfo.py
@@ -941,7 +941,7 @@ def get_cpu_info_from_cpuid():
 	'''
 
 	returncode, output = run_and_get_stdout([sys.executable, "-c", "import cpuinfo; print(cpuinfo.actual_get_cpu_info_from_cpuid())"])
-	if returncode != 0:
+	if (returncode != 0) or (output.strip() == 'None'):
 		return None
 	info = b64_to_obj(output)
 	return info
@@ -1557,7 +1557,7 @@ def get_cpu_info():
 # Make sure we are running on a supported system
 def _check_arch():
 	arch, bits = parse_arch(DataSource.raw_arch_string)
-	if not arch in ['X86_32', 'X86_64', 'ARM_7', 'ARM_8']:
+	if not arch in ['X86_32', 'X86_64', 'ARM_7', 'ARM_8', 'AARCH_64']:
 		raise Exception("py-cpuinfo currently only works on X86 and some ARM CPUs.")
 
 def main():

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ else:
     # Guess SSE2 or AVX2 capabilities
     cpu_info = cpuinfo.get_cpu_info()
     # SSE2
-    if 'sse2' in cpu_info['flags']:
+    if (cpu_info != None) and ('sse2' in cpu_info['flags']):
         print('SSE2 detected')
         CFLAGS.append('-DSHUFFLE_SSE2_ENABLED')
         sources += [f for f in glob('c-blosc/blosc/*.c') if 'sse2' in f]
@@ -152,7 +152,7 @@ else:
         elif os.name == 'nt':
             def_macros += [('__SSE2__', 1)]
     # AVX2
-    if 'avx2' in cpu_info['flags']:
+    if (cpu_info != None) and ('avx2' in cpu_info['flags']):
         print('AVX2 detected')
         CFLAGS.append('-DSHUFFLE_AVX2_ENABLED')
         sources += [f for f in glob('c-blosc/blosc/*.c') if 'avx2' in f]


### PR DESCRIPTION
Cpuinfo.py didn't check for "None\n" which is the result of `print(actual_get_cpu_info_from_cpuid())` on at least this aarch64 platform.

Rest of the fixes should be pretty readily apparent.

Cheers!