### PR TITLE
reset blocksize to default after fidgiting it in doctest

### DIFF
--- a/blosc/toplevel.py
+++ b/blosc/toplevel.py
@@ -111,6 +111,7 @@ def set_blocksize(blocksize):
     --------
 
     >>> blosc.set_blocksize(512)
+    >>> blosc.set_blocksize(0)
 
     """
 


### PR DESCRIPTION
The doctests for the blocksize -- specifically setting it to 512 -- causes a
random side-effect much later in the test-suite. The fix here is to simply
reset the blocksize to 0 (the default value, meaning an appropriate size will
be selected automaticall) afterwards. As the notes say, 'for expert users
only'.

Fixes #139