### PR TITLE
setup.py: Fix INCLUDE_SNAPPY=1 handling on 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ else:
     # env var 'CC' and not 'CXX'.
     if INCLUDE_SNAPPY:
         clibs.append( ('snappy', {'sources': glob('c-blosc/internal-complibs/snappy*/*.cc'), 
-                               'cflags':'-std=c++11 -lstdc++' } ) )
+                                  'cflags': ['-std=c++11', '-lstdc++'] } ) )
         inc_dirs += glob('c-blosc/internal-complibs/snappy*')
         def_macros += [('HAVE_SNAPPY',1)]
 


### PR DESCRIPTION
Passing `cflags` around as a string instead of list appears to work on Python 2.7 but on 3.6, `setuptools` fails with the error:

    $ export INCLUDE_SNAPPY=1
    $ python3.6 setup.py build_clib
    ...
    TypeError: can only concatenate list (not "str") to list

This fix makes it build on both 2.7 and 3.6 alike.