### PR TITLE
Including kwargs to the unpack_array API

### DIFF
--- a/blosc/test.py
+++ b/blosc/test.py
@@ -112,7 +112,7 @@ class TestCodec(unittest.TestCase):
 
         self.assertEqual(expected, blosc.decompress(bytearray(compressed)))
         self.assertEqual(expected, blosc.decompress(np.array([compressed])))
-        
+
     def test_decompress_releasegil(self):
         import numpy as np
         # assume the expected answer was compressed from bytes
@@ -132,7 +132,7 @@ class TestCodec(unittest.TestCase):
         self.assertEqual(expected, blosc.decompress(bytearray(compressed)))
         self.assertEqual(expected, blosc.decompress(np.array([compressed])))
         blosc.set_releasegil(False)
-        
+
     def test_decompress_input_types_as_bytearray(self):
         import numpy as np
         # assume the expected answer was compressed from bytes
@@ -250,6 +250,12 @@ class TestCodec(unittest.TestCase):
 
         # This should always raise an error
         self.assertRaises(ValueError, blosc.pack_array, ones)
+
+    def test_unpack_array_with_unicode_characters(self):
+        import numpy as np
+        input_array = np.array(['å', 'ç', 'ø', 'π', '˚'])
+        packed_array = blosc.pack_array(input_array)
+        np.testing.assert_array_equal(input_array, blosc.unpack_array(packed_array, encoding='UTF-8'))
 
     def test_unpack_array_exceptions(self):
         self.assertRaises(TypeError, blosc.unpack_array, 1.0)

--- a/blosc/toplevel.py
+++ b/blosc/toplevel.py
@@ -698,7 +698,7 @@ def pack_array(array, clevel=9, shuffle=blosc.SHUFFLE, cname='blosclz'):
     return packed_array
 
 
-def unpack_array(packed_array):
+def unpack_array(packed_array, **kwargs):
     """unpack_array(packed_array)
 
     Unpack (decompress) a packed NumPy array.
@@ -707,6 +707,9 @@ def unpack_array(packed_array):
     ----------
     packed_array : str / bytes
         The packed array to be decompressed.
+
+    **kwargs : fix_imports / encoding / errors
+        Optional parametes that can be passed to the pickle.loads API
 
     Returns
     -------
@@ -737,7 +740,10 @@ def unpack_array(packed_array):
     # First decompress the pickle
     pickled_array = _ext.decompress(packed_array, False)
     # ... and unpickle
-    array = pickle.loads(pickled_array)
+    if kwargs:
+        array = pickle.loads(pickled_array, **kwargs)
+    else:
+        array = pickle.loads(pickled_array)
 
     return array
 


### PR DESCRIPTION
This PR includes `**kwargs` options to the `unpack_array` API so that they can be used by the `pickle.loads` API: https://docs.python.org/3/library/pickle.html#pickle.loads.

This, for example, will allow users to pass an `encoding` option inorder to unpickle data in Python3.x that was pickled in Python2.x