### PR TITLE
initialize BloscError in Python3 too

### DIFF
--- a/blosc/blosc_extension.c
+++ b/blosc/blosc_extension.c
@@ -626,6 +626,13 @@ PyMODINIT_FUNC
 PyInit_blosc_extension(void) {
   PyObject *m = PyModule_Create(&blosc_def);
 
+
+  BloscError = PyErr_NewException("blosc_extension.error", NULL, NULL);
+  if (BloscError != NULL) {
+    Py_INCREF(BloscError);
+    PyModule_AddObject(m, "error", BloscError);
+  }
+
   /* Integer macros */
   PyModule_AddIntMacro(m, BLOSC_MAX_BUFFERSIZE);
   PyModule_AddIntMacro(m, BLOSC_MAX_THREADS);


### PR DESCRIPTION
Apparently, this was forgotten for Python3 and actually raising an exception from within c-blosc probably never really worked in Python3.