### PR TITLE
move numpy import into unpack_array

### DIFF
--- a/blosc/toplevel.py
+++ b/blosc/toplevel.py
@@ -8,7 +8,6 @@
 
 import os
 import sys
-import numpy as np
 from distutils.version import LooseVersion
 try:
     import cPickle as pickle
@@ -756,7 +755,8 @@ def unpack_array(packed_array, **kwargs):
     if kwargs and PY3X:
         array = pickle.loads(pickled_array, **kwargs)
         if all(isinstance(x, bytes) for x in array.tolist()):
-            array = np.array([x.decode('utf-8') for x in array.tolist()])
+            import numpy
+            array = numpy.array([x.decode('utf-8') for x in array.tolist()])
     else:
         array = pickle.loads(pickled_array)
 


### PR DESCRIPTION
With https://github.com/Blosc/python-blosc/pull/149/files the `import numpy` statement was added to `toplevel.py`. However this caused issues as outlined in #158 . The resolution is to move the import to the latest point possible. This way, you can use python-blosc without numpy UNLESS you use the `unpack_array` function. The assumption is, that if you are using this, you will have numpy installed anyway. This fixes the previous behaviour and respects the existing interface that numpy isn't a strict dependency of python-blosc.