### PR TITLE
Remove support for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ with relatively low entropy, like sparse data, time series, grids with
 regular-spaced values, etc.
 
 python-blosc a Python package that wraps Blosc.  python-blosc supports
-Python 2.7 and 3.3 or higher versions.
+Python 2.7 and 3.4 or higher versions.
 
 
 Installing

--- a/blosc/test.py
+++ b/blosc/test.py
@@ -11,7 +11,6 @@ import unittest
 # version number hack
 vi = sys.version_info
 PY27 = vi[0] == 2 and vi[1] == 7
-PY33 = vi[0] == 3 and vi[1] == 3
 PY3X = vi[0] == 3
 
 
@@ -252,7 +251,7 @@ class TestCodec(unittest.TestCase):
     def test_unpack_array_with_from_py27_exceptions(self):
         self.assertRaises(UnicodeDecodeError, blosc.unpack_array, self.PY_27_INPUT)
 
-    @unittest.skipIf(not PY3X or PY33, "Only required when running Python3.x, excluding Python3.3")
+    @unittest.skipIf(not PY3X, "Only required when running Python3.x")
     def test_unpack_array_with_unicode_characters_from_py27(self):
         import numpy as np
         out_array = np.array(['å', 'ç', 'ø', 'π', '˚'])

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -10,7 +10,7 @@ from sources, you are going to need a C compiler (GCC, clang and MSVC
 Also, there are situations where you may want to link with an already existing
 Blosc library in your system.  You can do that too.
 
-This package supports Python 2.7 and 3.3 or higher versions.
+This package supports Python 2.7 and 3.4 or higher versions.
 
 Installing from PyPI repository
 ===============================

--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,10 @@ if sys.version_info[0] == 2:
     if sys.version_info[1] < 7:
         exit_with_error("You need Python 2.7 or greater to install blosc!")
 elif sys.version_info[0] == 3:
-    if sys.version_info[1] < 3:
-        exit_with_error("You need Python 3.3 or greater to install blosc!")
+    if sys.version_info[1] < 4:
+        exit_with_error("You need Python 3.4 or greater to install blosc!")
 else:
-    exit_with_error("You need Python 2.7/3.3 or greater to install blosc!")
+    exit_with_error("You need Python 2.7/3.4 or greater to install blosc!")
 
 tests_require = ['numpy']
 
@@ -172,7 +172,6 @@ Intended Audience :: Science/Research
 License :: OSI Approved :: MIT License
 Programming Language :: Python
 Programming Language :: Python :: 2.7
-Programming Language :: Python :: 3.3
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6


### PR DESCRIPTION
Numpy no longer supports 3.3, so neither should we.