### PR TITLE
fix license listing in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -179,7 +179,7 @@ if __name__ == '__main__':
     Intended Audience :: Developers
     Intended Audience :: Information Technology
     Intended Audience :: Science/Research
-    License :: OSI Approved :: MIT License
+    License :: OSI Approved :: BSD License
     Programming Language :: Python
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3.4


### PR DESCRIPTION
The license listing is broken on:

https://pypi.org/project/blosc/

This should fix that.