### PR TITLE
include *.inc files too

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,5 @@ include *.txt *.rst
 include setup.py cpuinfo.py VERSION
 
 recursive-include blosc *.py *.c
-recursive-include c-blosc *.c *.h *.cpp *.hpp
+recursive-include c-blosc *.c *.h *.cpp *.hpp *.inc
 recursive-include LICENSES *


### PR DESCRIPTION
The 1.8.0 package on PyPi could not be installed, with the following
error:

    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LZ4=1 -DHAVE_ZLIB=1 -DHAVE_ZSTD=1 -Ic-blosc/blosc -Ic-blosc/internal-complibs/zstd-1.3.8 -Ic-blosc/internal-complibs/snappy-1.1.1 -Ic-blosc/internal-complibs/lz4-1.8.3 -Ic-blosc/internal-complibs/zlib-1.2.8 -Ic-blosc/internal-complibs/lz4-1.8.3 -Ic-blosc/internal-complibs/zstd-1.3.8/common -Ic-blosc/internal-complibs/zstd-1.3.8 -I/opt/python/2.7.14/include/python2.7 -c c-blosc/blosc/blosclz.c -o build/temp.linux-x86_64-2.7/c-blosc/blosc/blosclz.o -DSHUFFLE_SSE2_ENABLED -msse2
    c-blosc/blosc/blosclz.c:453:28: fatal error: blosclz_impl.inc: No such file or directory
     #include "blosclz_impl.inc"

This should fix that.