### PR TITLE
Page fault before the numpy benchmark

### DIFF
--- a/bench/compare-pack-ptr.py
+++ b/bench/compare-pack-ptr.py
@@ -48,7 +48,7 @@ out_ = np.zeros(in_.shape, dtype=in_.dtype)
 tic = time.time()
 np.copyto(out_, in_)
 toc = time.time()
-print("  Time for copying array with np.copyto and zeros    :     %.3f s" % (toc-tic,))
+print("  Time for copying array with np.copyto and zeros     :     %.3f s" % (toc-tic,))
 
 # Cause a page faults before the benchmark
 out_ = np.full_like(in_, fill_value=0)

--- a/bench/compare-pack-ptr.py
+++ b/bench/compare-pack-ptr.py
@@ -34,7 +34,7 @@ out_ = np.full_like(in_, fill_value=0)
 tic = time.time()
 np.copyto(out_, in_)
 toc = time.time()
-print("  Time for copying array with np.copy():     %.3f s" % (toc-tic,))
+print("  Time for copying array with np.copyto():     %.3f s" % (toc-tic,))
 print()
 
 for cname in blosc.compressor_list():

--- a/bench/compare-pack-ptr.py
+++ b/bench/compare-pack-ptr.py
@@ -53,7 +53,7 @@ for cname in blosc.compressor_list():
                            in_.size, in_.dtype.itemsize,
                            clevel=clevel, shuffle=True, cname=cname)
     ctoc = time.time()
-    out = np.empty(in_.size, dtype=in_.dtype)
+    out = np.full(in_.size, fill_value=0, dtype=in_.dtype)
     dtic = time.time()
     blosc.decompress_ptr(c, out.__array_interface__['data'][0])
     dtoc = time.time()

--- a/bench/compare-pack-ptr.py
+++ b/bench/compare-pack-ptr.py
@@ -40,14 +40,15 @@ np.copyto(out_, in_)
 toc = time.time()
 print("  Time for copying array with np.copyto and empty_like:     %.3f s" % (toc-tic,))
 
-# The numpy zeros_like doens't use calloc, but instead uses
+# Unlike numpy.zeros, numpy.zeros_like doens't use calloc, but instead uses
 # empty_like and explicitely assigns zeros, which is basically like calling
 # full like
+# Here we benchmark what happens when we allocate memory using calloc
 out_ = np.zeros(in_.shape, dtype=in_.dtype)
 tic = time.time()
 np.copyto(out_, in_)
 toc = time.time()
-print("  Time for copying array with np.copyto and zeros_like:     %.3f s" % (toc-tic,))
+print("  Time for copying array with np.copyto and zeros    :     %.3f s" % (toc-tic,))
 
 # Cause a page faults before the benchmark
 out_ = np.full_like(in_, fill_value=0)

--- a/bench/compare-pack-ptr.py
+++ b/bench/compare-pack-ptr.py
@@ -29,8 +29,10 @@ in_ = np.arange(N, dtype=np.int64)  # the trivial linear distribution
 #in_ = np.random.random_integers(0, 100, N)  # random distribution
 print(" ", in_)
 
+# Cause a page faults before the benchmark
+out_ = np.full_like(in_, fill_value=0)
 tic = time.time()
-out_ = np.copy(in_)
+np.copyto(out_, in_)
 toc = time.time()
 print("  Time for copying array with np.copy():     %.3f s" % (toc-tic,))
 print()

--- a/bench/compare-pack-ptr.py
+++ b/bench/compare-pack-ptr.py
@@ -29,12 +29,39 @@ in_ = np.arange(N, dtype=np.int64)  # the trivial linear distribution
 #in_ = np.random.random_integers(0, 100, N)  # random distribution
 print(" ", in_)
 
+tic = time.time()
+out_ = np.copy(in_)
+toc = time.time()
+print("  Time for copying array with np.copy():                    %.3f s" % (toc-tic,))
+
+out_ = np.empty_like(in_)
+tic = time.time()
+np.copyto(out_, in_)
+toc = time.time()
+print("  Time for copying array with np.copyto and empty_like:     %.3f s" % (toc-tic,))
+
+# The numpy zeros_like doens't use calloc, but instead uses
+# empty_like and explicitely assigns zeros, which is basically like calling
+# full like
+out_ = np.zeros(in_.shape, dtype=in_.dtype)
+tic = time.time()
+np.copyto(out_, in_)
+toc = time.time()
+print("  Time for copying array with np.copyto and zeros_like:     %.3f s" % (toc-tic,))
+
 # Cause a page faults before the benchmark
 out_ = np.full_like(in_, fill_value=0)
 tic = time.time()
 np.copyto(out_, in_)
 toc = time.time()
-print("  Time for copying array with np.copyto():     %.3f s" % (toc-tic,))
+print("  Time for copying array with np.copyto and full_like:      %.3f s" % (toc-tic,))
+
+out_ = np.full_like(in_, fill_value=0)
+tic = time.time()
+tic = time.time()
+out_[...] = in_
+toc = time.time()
+print("  Time for copying array with numpy assignment:             %.3f s" % (toc-tic,))
 print()
 
 for cname in blosc.compressor_list():

--- a/bench/compress_ptr.py
+++ b/bench/compress_ptr.py
@@ -30,7 +30,8 @@ arrays = ((np.arange(N, dtype=np.int64), "the arange linear distribution"),
           )
 
 in_ = arrays[0][0]
-out_ = np.empty(in_.size, dtype=in_.dtype)
+# cause page faults here
+out_ = np.full(in_.size, fill_value=0, dtype=in_.dtype)
 t0 = time.time()
 #out_ = np.copy(in_)
 out_ = ctypes.memmove(out_.__array_interface__['data'][0],
@@ -50,7 +51,8 @@ for (in_, label) in arrays:
                                    in_.size, in_.dtype.itemsize,
                                    clevel=clevel, shuffle=filter, cname=cname)
             tc = time.time() - t0
-            out = np.empty(in_.size, dtype=in_.dtype)
+            # cause page faults here
+            out = np.full(in_.size, fill_value=0, dtype=in_.dtype)
             t0 = time.time()
             blosc.decompress_ptr(c, out.__array_interface__['data'][0])
             td = time.time() - t0

--- a/bench/threadpool.py
+++ b/bench/threadpool.py
@@ -72,7 +72,7 @@ blosc.print_versions()
 blosc.set_blocksize( BLOCKSIZE )
 print("Creating NumPy stack with %d float32 elements:" %(m*N*N) )
 
-stack = np.zeros( [m,N,N], dtype=dtype )
+stack = np.full( [m,N,N], fill_value=0, dtype=dtype )
 xmesh, ymesh = np.meshgrid( np.arange(-N/2,N/2), np.arange(-N/2,N/2) )
 compress_mesh = (np.cos( xmesh ) + np.exp( -ymesh**2 / N )).astype(dtype)
 for J in np.arange(m):
@@ -88,10 +88,10 @@ bloscThreads = np.hstack( [1, powProduct[::-1]] )
 #poolThreads = np.arange( 1, maxThreads+1 )
 #bloscThreads = np.ones_like( poolThreads )
 
-solo_times = np.zeros_like( poolThreads, dtype='float64' )
-solo_unlocked_times = np.zeros_like( poolThreads, dtype='float64' )
-locked_times = np.zeros_like( poolThreads, dtype='float64' )
-unlocked_times = np.zeros_like( poolThreads, dtype='float64' )
+solo_times = np.full_like( poolThreads, fill_value=0, dtype='float64' )
+solo_unlocked_times = np.full_like( poolThreads, fill_value=0, dtype='float64' )
+locked_times = np.full_like( poolThreads, fill_value=0, dtype='float64' )
+unlocked_times = np.full_like( poolThreads, fill_value=0, dtype='float64' )
 
 for J in np.arange(nRuns):
     print( "Run  %d of %d" % (J+1, nRuns) )

--- a/bench/threadpool.py
+++ b/bench/threadpool.py
@@ -5,8 +5,8 @@ Created on Sun Oct 23 12:03:46 2016
 @author: Robert A. Mcleod - robbmcleod@gmail.com
 
 Compares running blosc with and without GIL release, and compares various
-combinations of ThreadPool threads and blosc-threads for operating on large 
-chunks.  The target is an image stack [50,1024,1024], where each frame can 
+combinations of ThreadPool threads and blosc-threads for operating on large
+chunks.  The target is an image stack [50,1024,1024], where each frame can
 be compressed as a chunk.
 """
 
@@ -27,7 +27,7 @@ BLOCKSIZE = 2**18
 CLEVEL = 4
 SHUFFLE = blosc.SHUFFLE
 COMPRESSOR = 'zstd'
-                 
+
 def compressSlice( args ):
     """
     args = (numpy array address, array_size, item_size, bytesList, bytesIndex)
@@ -36,12 +36,12 @@ def compressSlice( args ):
                        clevel=CLEVEL, shuffle=SHUFFLE, cname=COMPRESSOR )
 
 def decompressSlice( J, list_bytes ):
-    
+
     pass
 
 def compressStack( imageStack, blosc_threads = 1, pool_threads=maxThreads ):
     """
-    Does frame compression using a ThreadPool to distribute the load. 
+    Does frame compression using a ThreadPool to distribute the load.
     """
     blosc.set_nthreads( blosc_threads )
     tPool = ThreadPool( pool_threads )
@@ -54,18 +54,18 @@ def compressStack( imageStack, blosc_threads = 1, pool_threads=maxThreads ):
     for J in np.arange(num_slices):
         tArgs[J] = (imageStack[J,:,:].__array_interface__['data'][0], \
                     N*N, itemSize, bytesList, J)
-    
-    # All operations are done 'in-place' 
+
+    # All operations are done 'in-place'
     tPool.map( compressSlice, tArgs )
     tPool.close()
     tPool.join()
-    
+
 def decompressStack( imageShape, imageDtype, blosc_threads = 1, pool_threads=maxThreads ):
     blosc.set_nthreads( blosc_threads )
     tPool = ThreadPool( pool_threads )
-    
+
     num_slices = imageShape[0]
-    imageStack = np.empty( imageShape  )
+    imageStack = np.full(imageShape, fill_value=0)
 
 
 blosc.print_versions()
@@ -117,13 +117,13 @@ for J in np.arange(nRuns):
         compressStack( stack, blosc_threads=bloscThreads[I], pool_threads=poolThreads[I] )
         unlocked_times[I] += time.time() - t3
 
-        
+
     blosc.set_releasegil(False)
     for I in np.arange( len(poolThreads) ):
         t4 = time.time()
         compressStack( stack, blosc_threads=bloscThreads[I], pool_threads=poolThreads[I] )
         locked_times[I] += time.time() - t4
-      
+
 solo_times /= nRuns
 solo_unlocked_times /= nRuns
 locked_times /= nRuns

--- a/bench/threadpool.py
+++ b/bench/threadpool.py
@@ -72,7 +72,7 @@ blosc.print_versions()
 blosc.set_blocksize( BLOCKSIZE )
 print("Creating NumPy stack with %d float32 elements:" %(m*N*N) )
 
-stack = np.full( [m,N,N], fill_value=0, dtype=dtype )
+stack = np.zeros( [m,N,N], dtype=dtype )
 xmesh, ymesh = np.meshgrid( np.arange(-N/2,N/2), np.arange(-N/2,N/2) )
 compress_mesh = (np.cos( xmesh ) + np.exp( -ymesh**2 / N )).astype(dtype)
 for J in np.arange(m):
@@ -88,10 +88,10 @@ bloscThreads = np.hstack( [1, powProduct[::-1]] )
 #poolThreads = np.arange( 1, maxThreads+1 )
 #bloscThreads = np.ones_like( poolThreads )
 
-solo_times = np.full_like( poolThreads, fill_value=0, dtype='float64' )
-solo_unlocked_times = np.full_like( poolThreads, fill_value=0, dtype='float64' )
-locked_times = np.full_like( poolThreads, fill_value=0, dtype='float64' )
-unlocked_times = np.full_like( poolThreads, fill_value=0, dtype='float64' )
+solo_times = np.zeros_like( poolThreads, dtype='float64' )
+solo_unlocked_times = np.zeros_like( poolThreads, dtype='float64' )
+locked_times = np.zeros_like( poolThreads, dtype='float64' )
+unlocked_times = np.zeros_like( poolThreads, dtype='float64' )
 
 for J in np.arange(nRuns):
     print( "Run  %d of %d" % (J+1, nRuns) )


### PR DESCRIPTION
Page faults are actually stopping most modern computers from copying fast enough. This was at the heart of a recent discussion 
https://github.com/numpy/numpy/issues/11919

Before this patch:

```
Creating NumPy arrays with 10**8 int64/float64 elements:
compress_ptr.py:29: DeprecationWarning: This function is deprecated. Please call randint(0, 1000 + 1) instead
  (np.random.random_integers(0, 1000, N), "the random distribution")
  *** ctypes.memmove() *** Time for memcpy():	0.357 s	(2.09 GB/s)
```

After this patch


```
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
Creating NumPy arrays with 10**8 int64/float64 elements:
compress_ptr.py:29: DeprecationWarning: This function is deprecated. Please call randint(0, 1000 + 1) instead
  (np.random.random_integers(0, 1000, N), "the random distribution")
  *** ctypes.memmove() *** Time for memcpy():	0.110 s	(6.78 GB/s)
```