### PR TITLE
Fix: pip installation; add pyproject.toml to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include MANIFEST.in
 include *.txt *.rst
 include setup.py cpuinfo.py VERSION
+include pyproject.toml
 
 recursive-include blosc *.py *.c
 recursive-include c-blosc *.c *.h *.cpp *.hpp *.inc *.txt *.in


### PR DESCRIPTION
pip install fails right now because pip cannot find the skbuild module. This happens because the pyproject.toml file is not included in the source distribution.