### PR TITLE
Fix DeprecationWarning due to invalid escape sequence and use array.tobytes for Python 3.9.

### DIFF
--- a/blosc/toplevel.py
+++ b/blosc/toplevel.py
@@ -435,9 +435,9 @@ def compress(bytesobj, typesize=8, clevel=9, shuffle=blosc.SHUFFLE,
     Examples
     --------
 
-    >>> import array
+    >>> import array, sys
     >>> a = array.array('i', range(1000*1000))
-    >>> a_bytesobj = a.tostring()
+    >>> a_bytesobj = a.tobytes() if sys.version_info >= (3, 0, 0) else a.tostring()
     >>> c_bytesobj = blosc.compress(a_bytesobj, typesize=4)
     >>> len(c_bytesobj) < len(a_bytesobj)
     True
@@ -574,9 +574,9 @@ def decompress(bytesobj, as_bytearray=False):
     Examples
     --------
 
-    >>> import array
+    >>> import array, sys
     >>> a = array.array('i', range(1000*1000))
-    >>> a_bytesobj = a.tostring()
+    >>> a_bytesobj = a.tobytes() if sys.version_info >= (3, 0, 0) else a.tostring()
     >>> c_bytesobj = blosc.compress(a_bytesobj, typesize=4)
     >>> a_bytesobj2 = blosc.decompress(c_bytesobj)
     >>> a_bytesobj == a_bytesobj2

--- a/cpuinfo.py
+++ b/cpuinfo.py
@@ -550,7 +550,7 @@ def parse_arch(raw_arch_string):
 	raw_arch_string = raw_arch_string.lower()
 
 	# X86
-	if re.match('^i\d86$|^x86$|^x86_32$|^i86pc$|^ia32$|^ia-32$|^bepc$', raw_arch_string):
+	if re.match(r'^i\d86$|^x86$|^x86_32$|^i86pc$|^ia32$|^ia-32$|^bepc$', raw_arch_string):
 		arch = 'X86_32'
 		bits = 32
 	elif re.match('^x64$|^x86_64$|^x86_64t$|^i686-64$|^amd64$|^ia64$|^ia-64$', raw_arch_string):


### PR DESCRIPTION
Fixes #217 