### PR TITLE
Fix pip install failure from accessing cpu_info when it is None

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ if __name__ == '__main__':
         platforms = ['any'],
         cmake_args = [
           '-DBLOSC_DIR:PATH=%s' % os.environ.get('BLOSC_DIR', ''),
-          '-DDEACTIVATE_SSE2:BOOL=%s' % cmake_bool('DISABLE_BLOSC_SSE2' in os.environ or 'sse2' not in cpu_info['flags']),
+          '-DDEACTIVATE_SSE2:BOOL=%s' % cmake_bool(('DISABLE_BLOSC_SSE2' in os.environ) or (cpu_info is None) or ('sse2' not in cpu_info['flags'])),
           '-DDEACTIVATE_AVX2:BOOL=%s' % cmake_bool('DISABLE_BLOSC_AVX2' in os.environ),
           '-DDEACTIVATE_LZ4:BOOL=%s' % cmake_bool(not int(os.environ.get('INCLUDE_LZ4', '1'))),
           # Snappy is disabled by default

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ if __name__ == '__main__':
         cmake_args = [
           '-DBLOSC_DIR:PATH=%s' % os.environ.get('BLOSC_DIR', ''),
           '-DDEACTIVATE_SSE2:BOOL=%s' % cmake_bool(('DISABLE_BLOSC_SSE2' in os.environ) or (cpu_info is None) or ('sse2' not in cpu_info['flags'])),
-          '-DDEACTIVATE_AVX2:BOOL=%s' % cmake_bool('DISABLE_BLOSC_AVX2' in os.environ),
+          '-DDEACTIVATE_AVX2:BOOL=%s' % cmake_bool(('DISABLE_BLOSC_AVX2' in os.environ) or (cpu_info is None) or ('avx2' not in cpu_info['flags'])),
           '-DDEACTIVATE_LZ4:BOOL=%s' % cmake_bool(not int(os.environ.get('INCLUDE_LZ4', '1'))),
           # Snappy is disabled by default
           '-DDEACTIVATE_SNAPPY:BOOL=%s' % cmake_bool(not int(os.environ.get('INCLUDE_SNAPPY', '0'))),


### PR DESCRIPTION
If `cpuinfo` fails to import, then `cpu_info` is set to `None` at the top of `setup.py`.  But in the `sse2` check, `cpu_info` is accessed without first checking if it is `None`, causing the pip build to fail.

This fix errs on the conservative side, assuming that we do not want to build SSE2 if `cpuinfo` could not be imported.  It's possible a similar change is needed on the next line for AVX2, but I wasn't sure why there was no `'avx2' not in cpu_info['flags']` condition there in the first place.