### PR TITLE
Fix build error: blosc/c-blosc/README.md could not be found

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,5 @@ include *.txt *.rst
 include setup.py cpuinfo.py VERSION
 include pyproject.toml
 
-recursive-include blosc *.py *.c *.h *.txt *.in
+recursive-include blosc *.py *.c *.h *.txt *.in *.md
 recursive-include LICENSES *


### PR DESCRIPTION
The file `blosc/c-blosc/README.md` is missing in the sdist `blosc-1.10.0.tar.gz` on PyPI. Building from source fails with the following error (at least on my Windows system):

```
CMake Error at D:/Programs/CMake/share/cmake-3.18/Modules/CPack.cmake:561 (message):
  CPack package description file:
  "D:/Build/blosc/blosc-1.10.0/blosc/c-blosc/README.md" could not be found.
Call Stack (most recent call first):
  D:/Programs/CMake/share/cmake-3.18/Modules/CPack.cmake:565 (cpack_check_file_exists)
  blosc/c-blosc/CMakeLists.txt:373 (include)


-- Performing Test Weak Link MODULE -> SHARED (gnu_ld_ignore) - Failed
-- Performing Test Weak Link MODULE -> SHARED (osx_dynamic_lookup) - Failed
-- Performing Test Weak Link MODULE -> SHARED (no_flag) - Failed
_modinit_prefix:PyInit_
-- Configuring incomplete, errors occurred!
```