### PR TITLE
fix: try to fix error on PyPy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ if __name__ == '__main__':
 
     # Blosc version
     with open('VERSION') as f:
-        VERSION = .read().strip()
+        VERSION = f.read().strip()
 
     # Create the version.py file
     with open('blosc/version.py', 'w') as f:

--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,12 @@ if __name__ == '__main__':
         long_description = f.read()
 
     # Blosc version
-    VERSION = open('VERSION').read().strip()
+    with open('VERSION') as f:
+        VERSION = .read().strip()
+
     # Create the version.py file
-    open('blosc/version.py', 'w').write('__version__ = "%s"\n' % VERSION)
+    with open('blosc/version.py', 'w') as f:
+        f.write('__version__ = "%s"\n' % VERSION)
 
     def cmake_bool(cond):
         return 'ON' if cond else 'OFF'


### PR DESCRIPTION
This might resolve an issue where this does not properly write a file when running on PyPy, due to the assumption that the garbage collector will run every line, which is not true on PyPy. It is also more correct usage of the Python language. See https://github.com/joerick/cibuildwheel/issues/533 and https://foss.heptapod.net/pypy/pypy/-/issues/3382 

If you run CPython with warnings on, it will spit out warnings when it sees this, too, by the way:

```bash
$ echo "open('README.md').read()" > tmp.py
$ python3 -Wd tmp.py
```
```
tmp.py:1: ResourceWarning: unclosed file <_io.TextIOWrapper name='README.md' mode='r' encoding='UTF-8'>
  open("README.md").read()
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```
