### PR TITLE
Add aarch64 wheel build support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,3 +34,31 @@ jobs:
         python blosc/test.py
       env:
         PYTHONPATH: '.'
+
+  test-aarch64:
+    name: "Build and test on aarch64"
+    strategy:
+      matrix:
+        pyver: [cp37-cp37m, cp38-cp38, cp39-cp39]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    env:
+      py: /opt/python/${{ matrix.pyver }}/bin/python
+      img: quay.io/pypa/manylinux2014_aarch64
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v1
+    - name: Install and run tests
+      run: |
+            docker run --rm -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
+            ${{ env.img }} \
+            bash -exc '${{ env.py }} -m venv .env && \
+            source .env/bin/activate && \
+            python -m pip install --upgrade pip && \
+            python -m pip install -r requirements.txt && \
+            python setup.py install && \
+            python blosc/test.py && \
+            deactivate'

--- a/.github/workflows/cibuildwheels.yml
+++ b/.github/workflows/cibuildwheels.yml
@@ -10,11 +10,17 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels for ${{ matrix.arch }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+                arch: [auto, aarch64]
+        exclude:
+          - os: windows-latest
+            arch: aarch64
+          - os: macos-latest
+            arch: aarch64
 
     steps:
       - name: Checkout repo
@@ -26,6 +32,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.7'
+
+      - name: Set up QEMU
+        if: ${{ matrix.arch == 'aarch64' }}
+        uses: docker/setup-qemu-action@v1
 
       - name: Install Ninja
         uses: seanmiddleditch/gha-setup-ninja@master
@@ -72,6 +82,7 @@ jobs:
         env:
           CIBW_BUILD: 'cp37-* cp38-* cp39-*'
           CIBW_SKIP: '*-manylinux*_i686'
+          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           CIBW_BEFORE_BUILD: pip install -r requirements.txt
           CIBW_BEFORE_TEST: pip install numpy
           CIBW_TEST_COMMAND: python {project}/blosc/test.py


### PR DESCRIPTION
Added aarch64 wheel build support.
Related to https://github.com/Blosc/python-blosc/issues/249, @oscargm98 Could you please review this PR?