### PR TITLE
add cmake folder to MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include MANIFEST.in
 include *.txt *.rst
 include setup.py cpuinfo.py VERSION
 include pyproject.toml
+graft cmake
 
 recursive-include blosc *.py *.c *.h *.txt *.in *.md
 recursive-include LICENSES *


### PR DESCRIPTION
https://github.com/Blosc/python-blosc/pull/244#issuecomment-937527700; the FindBlosc.cmake file is missing in the PyPI sdist.