### PR TITLE
Variable `long_description` defined multiple times

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,6 @@ from textwrap import dedent
 
 if __name__ == '__main__':
 
-    with io.open('README.rst', encoding='utf-8') as f:
-        long_description = f.read()
-
     try:
         import cpuinfo
         cpu_info = cpuinfo.get_cpu_info()


### PR DESCRIPTION
We keep the last definition, the one that was actually used, shadowing the first definition.

File `README.rst` is an ASCII file, so `encoding='utf-8'` is not really required. If it becomes an issue someday, if non-ASCII characters are added to `README.rst`, you may add the `encoding='utf-8'` keyword argument.

From https://docs.python.org/3.7/library/functions.html#open:
> _encoding_ is the name of the encoding used to decode or encode the file. This should only be used in text mode. The default encoding is platform dependent (whatever [`locale.getpreferredencoding()`](https://docs.python.org/3.7/library/locale.html#locale.getpreferredencoding) returns), but any [text encoding](https://docs.python.org/3.7/glossary.html#term-text-encoding) supported by Python can be used. See the [`codecs`](https://docs.python.org/3.7/library/codecs.html#module-codecs) module for the list of supported encodings.

This fixes an LGTM.com alert:
https://lgtm.com/projects/g/Blosc/python-blosc/snapshot/bbcfd43b4e870a1e00cc44ad21d4917bca0e4d8a/files/setup.py?sort=name&dir=ASC&mode=heatmap#x59e6f249c4a980ce:1