### PR TITLE
Useless inheritance from `object`

### DIFF
--- a/blosc/test.py
+++ b/blosc/test.py
@@ -169,7 +169,7 @@ class TestCodec(unittest.TestCase):
                           typesize=1, cname='foo')
 
         # Create a simple mock to avoid having to create a buffer of 2 GB
-        class LenMock(object):
+        class LenMock:
             def __len__(self):
                 return blosc.MAX_BUFFERSIZE+1
         self.assertRaises(ValueError, blosc.compress, LenMock(), typesize=1)


### PR DESCRIPTION
Fixes this DeepSource.io alert:
https://deepsource.io/gh/DimitriPapadopoulos/python-blosc/issue/PYL-R0205/occurrences
> The class is inheriting from `object`, which is implicit under Python 3, hence can be safely removed from bases.