### PR TITLE
Use `min` builtin

### DIFF
--- a/blosc/__init__.py
+++ b/blosc/__init__.py
@@ -73,8 +73,7 @@ set_releasegil(False)
 # Internal Blosc threading
 nthreads = ncores = detect_number_of_cores()
 # Protection against too many cores
-if nthreads > 8:
-    nthreads = 8
+nthreads = min(nthreads, 8)
 set_nthreads(nthreads)
 blosclib_version = "%s (%s)" % (VERSION_STRING, VERSION_DATE)
 import atexit


### PR DESCRIPTION
Fixes this DeepSource.io alert:
https://deepsource.io/gh/DimitriPapadopoulos/python-blosc/issue/PTC-W0041/occurrences
> It is unnecessary to use an _if_ statement to check the minimum of two values and then assign the value to a name. You can use the `min` built-in do do this. It is straightforward and more readable.