### PR TITLE
Unnecessary generator

### DIFF
--- a/blosc/__init__.py
+++ b/blosc/__init__.py
@@ -60,7 +60,7 @@ from blosc.toplevel import (
 # Dictionaries for the maps between compressor names and libs
 cnames = compressor_list()
 # Map for compression names and libs
-cname2clib = dict((name, clib_info(name)[0]) for name in cnames)
+cname2clib = {name: clib_info(name)[0] for name in cnames}
 # Map for compression libraries and versions
 clib_versions = dict(clib_info(name) for name in cnames)
 


### PR DESCRIPTION
Fixes this DeepSource.io alert:
https://deepsource.io/gh/DimitriPapadopoulos/python-blosc/issue/PTC-W0015/occurrences
> It is unnecessary to use `list`, `set`, `dict` around a generator expression to get an object of that type since there are comprehensions for these types.