### PR TITLE
Do not use bare `except`

### DIFF
--- a/blosc/toplevel.py
+++ b/blosc/toplevel.py
@@ -376,7 +376,7 @@ def _check_bytesobj(bytesobj):
 def _check_byteslike(bytes_like):
     try:
         memoryview(bytes_like)
-    except:
+    except Exception:
         raise TypeError("Input type %s must be a bytes-like object that supports Python Buffer Protocol" % type(bytes_like))
 
 


### PR DESCRIPTION
Fixes this DeepSource.io alert:
https://deepsource.io/gh/DimitriPapadopoulos/python-blosc/issue/FLK-E722/occurrences
> Using `except` without a specific exception can be error prone.

See [PEP 8](https://www.python.org/dev/peps/pep-0008/#programming-recommendations):
> When catching exceptions, mention specific exceptions whenever possible instead of using a bare `except:` clause:
> ```
> try:
>     import platform_specific_module
> except ImportError:
>     platform_specific_module = None
> ```
> A bare `except:` clause will catch SystemExit and KeyboardInterrupt exceptions, making it harder to interrupt a program with Control-C, and can disguise other problems. If you want to catch all exceptions that signal program errors, use `except Exception:` (bare except is equivalent to `except BaseException:`).
> 
> A good rule of thumb is to limit use of bare 'except' clauses to two cases:
> 1.  If the exception handler will be printing out or logging the traceback; at least the user will be aware that an error has occurred.
> 2. If the code needs to do some cleanup work, but then lets the exception propagate upwards with raise. try...finally can be a better way to handle this case.
