### PR TITLE
Useless else clause detected on the loop

### DIFF
--- a/blosc/toplevel.py
+++ b/blosc/toplevel.py
@@ -815,8 +815,7 @@ def os_release_pretty_name():
                     return value
         except IOError:
             pass
-    else:
-        return None
+    return None
 
 def print_versions():
     """Print all the versions of software that python-blosc relies on."""


### PR DESCRIPTION
Fixes this DeepSource.io alert:
https://deepsource.io/gh/DimitriPapadopoulos/python-blosc/issue/PYL-W0120/occurrences
> When a loop specifies no break statement, the else clause will always execute when the loop sequence is empty, thus making it useless. It is recommended to have the statements under else in the same scope as the loop itself. If the else clause does not always execute at the end of a loop clause, then the code should add a break statement within the loop block.