### PR TITLE
Re-definition of builtin function

### DIFF
--- a/bench/compress_ptr.py
+++ b/bench/compress_ptr.py
@@ -44,11 +44,11 @@ print("\nTimes for compressing/decompressing with clevel=%d and %d threads" % (
 for (in_, label) in arrays:
     print("\n*** %s ***" % label)
     for cname in blosc.compressor_list():
-        for filter in [blosc.NOSHUFFLE, blosc.SHUFFLE, blosc.BITSHUFFLE]:
+        for shuffle in [blosc.NOSHUFFLE, blosc.SHUFFLE, blosc.BITSHUFFLE]:
             t0 = time.time()
             c = blosc.compress_ptr(in_.__array_interface__['data'][0],
                                    in_.size, in_.dtype.itemsize,
-                                   clevel=clevel, shuffle=filter, cname=cname)
+                                   clevel=clevel, shuffle=shuffle, cname=cname)
             tc = time.time() - t0
             # cause page faults here
             out = np.full(in_.size, fill_value=0, dtype=in_.dtype)


### PR DESCRIPTION
Fixes this DeepSource.io alert:
https://deepsource.io/gh/DimitriPapadopoulos/python-blosc/issue/PYL-W0622/occurrences
> Defining a local variable or function with the same name as a built-in object makes the built-in object unusable within the current scope and makes the code prone to bugs.

Not to mention that my editor would highlight these occurrences of `filter` as a built-in function, which is disturbing.