### PR TITLE
Avoid starting a process with shell intervention

### DIFF
--- a/blosc/toplevel.py
+++ b/blosc/toplevel.py
@@ -38,7 +38,7 @@ def detect_number_of_cores():
             if isinstance(ncpus, int) and ncpus > 0:
                 return ncpus
         else:  # OSX:
-            return int(os.popen2("sysctl -n hw.ncpu")[1].read())
+            return int(os.popen2(("sysctl", "-n", "hw.ncpu"))[1].read())
     # Windows:
     if "NUMBER_OF_PROCESSORS" in os.environ:
         ncpus = int(os.environ["NUMBER_OF_PROCESSORS"])


### PR DESCRIPTION
This is flagged as a security issue by code analysis tools such as DeepSource.io:
>	Spawning of a subprocess using a command shell is dangerous as
>	it is vulnerable to various shell injection attacks. Great care
>	should be taken to sanitize all input in order to mitigate this
>	risk. Calls of this type are identified by the use of certain
>	commands which are known to use shells.
>	[...]
>	It is recommended to use functions that don't spawn a shell.
>	If you must use them, use `shlex.quote` to sanitize the input
>	by changing it to the shell-escaped version.

See:
https://docs.python.org/2/library/subprocess.html#replacing-os-popen-os-popen2-os-popen3

We do not necessarily have a security issue in this specific case, but why start a shell any way?

**Note:** `os.popen2` has been deprecated since Python 2.6 and is obsolete, but let's handle that elsewhere:
https://docs.python.org/2/library/os.html#os.popen2
> _Deprecated since version 2.6:_ This function is obsolete. Use the [subprocess](https://docs.python.org/2/library/subprocess.html#module-subprocess) module. Check especially the [Replacing Older Functions with the subprocess Module](https://docs.python.org/2/library/subprocess.html#subprocess-replacements) section.
