### PR TITLE
Apply some pyupgrade suggestions

### DIFF
--- a/bench/compress_ptr.py
+++ b/bench/compress_ptr.py
@@ -43,7 +43,7 @@ print("\nTimes for compressing/decompressing with clevel=%d and %d threads" % (
 for (in_, label) in arrays:
     print("\n*** %s ***" % label)
     for cname in blosc.compressor_list():
-        for shuffle in [blosc.NOSHUFFLE, blosc.SHUFFLE, blosc.BITSHUFFLE]:
+        for shuffle in (blosc.NOSHUFFLE, blosc.SHUFFLE, blosc.BITSHUFFLE):
             t0 = time.time()
             c = blosc.compress_ptr(in_.__array_interface__['data'][0],
                                    in_.size, in_.dtype.itemsize,

--- a/blosc/toplevel.py
+++ b/blosc/toplevel.py
@@ -337,7 +337,7 @@ def free_resources():
 
 
 def _check_shuffle(shuffle):
-    if shuffle not in [blosc.NOSHUFFLE, blosc.SHUFFLE, blosc.BITSHUFFLE]:
+    if shuffle not in (blosc.NOSHUFFLE, blosc.SHUFFLE, blosc.BITSHUFFLE):
         raise ValueError("shuffle can only be one of NOSHUFFLE, SHUFFLE"
                          " and BITSHUFFLE.")
     if (shuffle == blosc.BITSHUFFLE and


### PR DESCRIPTION
* The default mode of `open()` is `'r'`, a synonym of `'rt'`:
  	https://docs.python.org/3/library/functions.html#open
* `IOError` is kept for compatibility with previous versions; starting from Python 3.3, it is an alias of `OSError`:
  	https://docs.python.org/3/library/exceptions.html#IOError