### PR TITLE
Remove deleted LICENSES directory from MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,4 +5,3 @@ include pyproject.toml
 graft cmake
 
 recursive-include blosc *.py *.c *.h *.txt *.in *.md
-recursive-include LICENSES *


### PR DESCRIPTION
Directory deleted by 3f3002b.

This will fix this CI warning:
```
reading manifest template 'MANIFEST.in'
warning: no files found matching '*' under directory 'LICENSES'
adding license file 'LICENSE.txt'
```