### PR TITLE
Redundant wheel in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "scikit-build", "cmake", "ninja"]
+requires = ["setuptools", "scikit-build", "cmake", "ninja"]


### PR DESCRIPTION
The backend adds the wheel dependency automatically:
> The `setuptools` package implements the `build_sdist` command and the `wheel` package implements the `build_wheel` command; the latter is a dependency of the former exposed via [**PEP 517**](https://peps.python.org/pep-0517/) hooks.

Listing it explicitly in the documentation was a historical mistake and has been fixed since in pypa/setuptools@f7d30a9.