### PR TITLE
Drop Python 3.7, minimal version is now 3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3
@@ -37,7 +37,7 @@ jobs:
     name: "Build and test on aarch64"
     strategy:
       matrix:
-        pyver: [cp37-cp37m, cp38-cp38, cp39-cp39]
+        pyver: [cp38-cp38, cp311-cp311]
       fail-fast: false
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/cibuildwheels.yml
+++ b/.github/workflows/cibuildwheels.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Set up QEMU
         if: ${{ matrix.arch == 'aarch64' }}
@@ -52,7 +52,7 @@ jobs:
           python -m pip install cibuildwheel
           python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: 'cp37-win32 cp38-win32 cp39-win32 cp310-win32 cp311-win32'
+          CIBW_BUILD: 'cp38-win32 cp39-win32 cp310-win32 cp311-win32'
           CIBW_BEFORE_BUILD: pip install -r requirements.txt
           CIBW_BEFORE_TEST: pip install numpy
           CIBW_TEST_COMMAND: python -m blosc.test
@@ -69,7 +69,7 @@ jobs:
           python -m pip install cibuildwheel
           python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: 'cp37-win_amd64 cp38-win_amd64 cp39-win_amd64 cp310-win_amd64 cp311-win_amd64'
+          CIBW_BUILD: 'cp38-win_amd64 cp39-win_amd64 cp310-win_amd64 cp311-win_amd64'
           CIBW_BEFORE_BUILD: pip install -r requirements.txt
           CIBW_BEFORE_TEST: pip install numpy
           CIBW_TEST_COMMAND: python -m blosc.test
@@ -81,7 +81,7 @@ jobs:
           python -m pip install cibuildwheel
           python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: 'cp37-* cp38-* cp39-* cp310-* cp311-*'
+          CIBW_BUILD: 'cp38-* cp39-* cp310-* cp311-*'
           CIBW_SKIP: '*-manylinux*_i686'
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           CIBW_BEFORE_BUILD: pip install -r requirements.txt
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Setup Python
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Install requirements
         run: |

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ with relatively low entropy, like sparse data, time series, grids with
 regular-spaced values, etc.
 
 python-blosc a Python package that wraps Blosc.  python-blosc supports
-Python 3.7 or higher versions.
+Python 3.8 or higher versions.
 
 
 Installing

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ if __name__ == '__main__':
     Intended Audience :: Science/Research
     License :: OSI Approved :: BSD License
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -70,7 +69,7 @@ if __name__ == '__main__':
         description = 'Blosc data compressor',
         long_description = long_description,
         classifiers = [c for c in classifiers.split("\n") if c],
-        python_requires=">=3.7",
+        python_requires=">=3.8",
         author = 'The Blosc development team',
         author_email = 'blosc@blosc.org',
         maintainer = 'The Blosc development team',


### PR DESCRIPTION
Because NumPy is a dependency, follow drop schedule of NEP-29:
https://numpy.org/neps/nep-0029-deprecation_policy.html#drop-schedule