### PR TITLE
Variant for the © symbol: (C) → (c)

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,9 +2,9 @@ BSD License
 
 For python-blosc - A Python wrapper for the Blosc compression library
 
-Copyright (C) 2010-2012 Francesc Alted (faltet@gmail.com)
-Copyright (C) 2013-2019 Francesc Alted <francesc@blosc.org>, Valentin Haenel <valentin@haenel.co>
-Copyright (C) 2019-present The Blosc Development Team <blosc@blosc.org>
+Copyright (c) 2010-2012 Francesc Alted (faltet@gmail.com)
+Copyright (c) 2013-2019 Francesc Alted <francesc@blosc.org>, Valentin Haenel <valentin@haenel.co>
+Copyright (c) 2019-present The Blosc Development Team <blosc@blosc.org>
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:


### PR DESCRIPTION
As in https://github.com/Blosc/c-blosc2/pull/472.