### PR TITLE
Fixes #325: Include Assembly Code in Manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,4 @@ include setup.py VERSION
 include pyproject.toml
 graft cmake
 
-recursive-include blosc *.py *.c *.h *.txt *.in *.md
+recursive-include blosc *.py *.c *.h *.S *.txt *.in *.md


### PR DESCRIPTION
Issue #325 describes an issue trying to build with Python 3.12.  The root cause is suggested by these error messages:

```
/usr/bin/ld: blosc/c-blosc/blosc/CMakeFiles/blosc_shared.dir//internal-complibs/zstd-1.5.2/decompress/huf_decompress.c.o: in function HUF_decompress4X1_usingDTable_internal_bmi2_asm': huf_decompress.c:(.text+0x2c2b): undefined reference to HUF_decompress4X1_usingDTable_internal_bmi2_asm_loop'
/usr/bin/ld: blosc/c-blosc/blosc/CMakeFiles/blosc_shared.dir//internal-complibs/zstd-1.5.2/decompress/huf_decompress.c.o: in function HUF_decompress4X2_usingDTable_internal_bmi2_asm': huf_decompress.c:(.text+0x6a58): undefined reference to HUF_decompress4X2_usingDTable_internal_bmi2_asm_loop'
/usr/bin/ld: blosc/c-blosc/blosc/libblosc.so.1.21.3: hidden symbol `HUF_decompress4X1_usingDTable_internal_bmi2_asm_loop' isn't defined
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
```

The “hidden symbol” message is a red herring.  The real problem is that these symbols are defined in an Assembly language source file `blosc/c-blosc/internal-complibs/zstd-1.5.2/decompress/huf_decompress_amd64.S` which isn't being packaged in.

This Pull Request updates `MANIFEST.in` to recursively include all `.S` files.