### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
     name: "Build and test on aarch64"
     strategy:
       matrix:
-        pyver: [cp310-cp310, cp312-cp312]
+        pyver: [cp310-cp310, cp313-cp313]
       fail-fast: false
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/cibuildwheels.yml
+++ b/.github/workflows/cibuildwheels.yml
@@ -52,7 +52,7 @@ jobs:
           python -m pip install cibuildwheel
           python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: 'cp39-win32 cp310-win32 cp311-win32 cp312-win32'
+          CIBW_BUILD: 'cp39-win32 cp310-win32 cp311-win32 cp312-win32, cp313-win32'
           CIBW_BEFORE_BUILD: pip install -r requirements.txt
           CIBW_BEFORE_TEST: pip install numpy
           CIBW_TEST_COMMAND: python -m blosc.test
@@ -69,7 +69,7 @@ jobs:
           python -m pip install cibuildwheel
           python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: 'cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64'
+          CIBW_BUILD: 'cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64 cp313-win_amd64'
           CIBW_BEFORE_BUILD: pip install -r requirements.txt
           CIBW_BEFORE_TEST: pip install numpy
           CIBW_TEST_COMMAND: python -m blosc.test
@@ -81,7 +81,7 @@ jobs:
           python -m pip install cibuildwheel
           python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: 'cp39-* cp310-* cp311-* cp312-*'
+          CIBW_BUILD: 'cp39-* cp310-* cp311-* cp312-* cp313-*'
           CIBW_SKIP: '*-manylinux*_i686'
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ if __name__ == '__main__':
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: 3 :: Only
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: System :: Archiving :: Compression


### PR DESCRIPTION
This adds support for Python 3.13, which was released a little while ago. I hope it's helpful - I'm happy to try and fix any issues found, or make any other changes needed.

The motivation here is to have wheels for Python 3.13 available.